### PR TITLE
Resource identifier / Add configuration for the identifier prefix.

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -15,6 +15,7 @@ import org.fao.geonet.GeonetContext;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.search.CodeListTranslator;
 import org.fao.geonet.kernel.search.Translator;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.fao.geonet.constants.Geonet;
@@ -97,6 +98,30 @@ public final class XslUtil
         return "";
     }
 
+    /**
+     * Get a setting value
+     * @param key
+     * @return
+     */
+    public static String getSettingValue(String key) {
+        if (key == null) {
+            return "";
+        }
+
+        final ServiceContext serviceContext = ServiceContext.get();
+        if (serviceContext != null) {
+            SettingManager settingsMan = serviceContext.getBean(SettingManager.class);
+            if (settingsMan != null) {
+                String value = settingsMan.getValue(key);
+                if (value != null) {
+                    return value;
+                } else {
+                    return "";
+                }
+            }
+        }
+        return "";
+    }
     /** 
 	 * Check if bean is defined in the context
 	 * 

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -357,6 +357,8 @@
     "system/platform/subVersion-help": "Sub-version:",
     "system/csw/transactionUpdateCreateXPath": "Create element if it does not exist when using XPath in CSW trasaction.",
     "system/csw/transactionUpdateCreateXPath-help": "If not checked, only existing element could be updated.",
+    "metadata/resourceIdentifierPrefix": "Resource identifier prefix",
+    "metadata/resourceIdentifierPrefix-help": "In the editor, a suggestion provides the capability to compute the resource identifier automatically. This identifier is computed by concatenating this prefix with the metadata identifier (eg. http://localhost:8080/geonetwork/a1fd6bb7-6425-48b6-bca3-13c9e1bc4ab1).",
     "metadataAndTemplates": "Metadata & templates",
     "loadSchemaSamplesOrTemplates": "Load samples and templates for metadata standards",
     "listOfSchemas": "Standards available",

--- a/web-ui/src/main/resources/catalog/locales/fr-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-admin.json
@@ -326,6 +326,8 @@
     "system/platform/subVersion-help": "Sous-version:",
     "system/csw/transactionUpdateCreateXPath": "Autoriser la création de nouveaux éléments lors de l'utilisation des XPath dans dans les transactions CSW.",
     "system/csw/transactionUpdateCreateXPath-help": "Si non sélectionné, seuls les éléments existant peuvent être mis à jour.",
+    "metadata/resourceIdentifierPrefix": "Préfixe pour l'identifiant de le ressource",
+    "metadata/resourceIdentifierPrefix-help": "Dans l'éditeur, il est possible de calculer un identifiant pour la ressource automatiquement à l'aide des suggestions. Cet identifiant est calculé par la concaténation de ce préfixe avec l'identifiant de la fiche (eg. http://localhost:8080/geonetwork/a1fd6bb7-6425-48b6-bca3-13c9e1bc4ab1).",
     "metadataAndTemplates": "Metadonnées et modèles",
     "loadSchemaSamplesOrTemplates": "Charger les exemples et les modèles",
     "listOfSchemas": "Standards disponibles",

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -646,6 +646,9 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES 
   ('metadata/editor/schemaConfig', '{"iso19110":{"defaultTab":"default","displayToolTip":false,"related":{"display":true,"readonly":true,"categories":["dataset"]},"validation":{"display":true}},"iso19139":{"defaultTab":"default","displayToolTip":false,"related":{"display":true,"categories":[]},"suggestion":{"display":true},"validation":{"display":true}},"dublin-core":{"defaultTab":"default","related":{"display":true,"readonly":false,"categories":["parent","onlinesrc"]}}}', 0, 10000, 'n');
 
+
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/resourceIdentifierPrefix', 'http://localhost:8080/geonetwork/', 0, 10001, 'n');
+
 INSERT INTO HarvesterSettings (id, parentid, name, value) VALUES  (1,NULL,'harvesting',NULL);
 
 -- ======================================================================

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v2110/2-migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v2110/2-migrate-default.sql
@@ -176,6 +176,8 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES
   ('metadata/editor/schemaConfig', '{"iso19110":{"defaultTab":"default","displayToolTip":false,"related":{"display":true,"readonly":true,"categories":["dataset"]},"validation":{"display":true}},"iso19139":{"defaultTab":"inspire","displayToolTip":false,"related":{"display":true,"categories":[]},"suggestion":{"display":true},"validation":{"display":true}},"dublin-core":{"defaultTab":"default","related":{"display":true,"readonly":false,"categories":["parent","onlinesrc"]},}}', 0, 10000, 'n');
 
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/resourceIdentifierPrefix', 'http://localhost:8080/geonetwork/', 0, 10001, 'n');
+
 
 ALTER TABLE StatusValues ADD displayorder int;
 


### PR DESCRIPTION
To provide more flexibility on the type of resource identifier added by the suggestion mechanism a new configuration option is added to the administration and is used when a resource identifier is computed.
## Configuration

![image](https://cloud.githubusercontent.com/assets/1701393/4926115/b553c0ec-6530-11e4-8258-30c82aed1ebb.png)
## Suggestion

![image](https://cloud.githubusercontent.com/assets/1701393/4926124/c14787a8-6530-11e4-8dc7-5a933b736e09.png)
## Resource identifier

![image](https://cloud.githubusercontent.com/assets/1701393/4926120/bb9b6d06-6530-11e4-8b09-737962833311.png)
